### PR TITLE
chore: atualizando versão da imagem para java 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ ARG TARGETPLATFORM
 ENV DOWNLOAD_URL=invalid
 ENV ZULU_TAR=invalid
 RUN case "${TARGETPLATFORM}" in \
-         "linux/amd64")     DOWNLOAD_URL=https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux_x64.tar.gz               \
-                            ZULU_TAR="zulu17.28.13-ca-jdk17.0.0-linux_x64"        ;; \
-         "linux/arm64")     DOWNLOAD_URL=https://cdn.azul.com/zulu/bin/zulu17.28.13-ca-jdk17.0.0-linux_aarch64.tar.gz           \
-                            ZULU_TAR="zulu17.28.13-ca-jdk17.0.0-linux_aarch64"    ;; \
+         "linux/amd64")     DOWNLOAD_URL=https://cdn.azul.com/zulu/bin/zulu21.44.17-ca-jdk21.0.8-linux_x64.tar.gz               \
+                            ZULU_TAR="zulu21.44.17-ca-jdk21.0.8-linux_x64"        ;; \
+         "linux/arm64")     DOWNLOAD_URL=https://cdn.azul.com/zulu/bin/zulu21.44.17-ca-jdk21.0.8-linux_aarch64.tar.gz           \
+                            ZULU_TAR="zulu21.44.17-ca-jdk21.0.8-linux_aarch64"    ;; \
     esac && \
     apt-get update -qq && apt-get upgrade -qq --autoremove --purge && \
     apt-get install -qq wget git java-common libasound2 libxi6 libxtst6 && \
@@ -33,12 +33,12 @@ RUN case "${TARGETPLATFORM}" in \
     mkdir -p /opt/maven /opt/jdk && \
     wget ${DOWNLOAD_URL} && \
     tar -C /opt/jdk -xzf ./${ZULU_TAR}.tar.gz && \
-    mv /opt/jdk/${ZULU_TAR} /opt/jdk/zulu17 && \
+    mv /opt/jdk/${ZULU_TAR} /opt/jdk/zulu21 && \
     rm ./${ZULU_TAR}.tar.gz && \
     wget https://dlcdn.apache.org/maven/maven-3/3.8.2/binaries/apache-maven-3.8.2-bin.tar.gz && \
     tar -C /opt/maven/ -xzf ./apache-maven-3.8.2-bin.tar.gz && \
     rm ./apache-maven-3.8.2-bin.tar.gz
 
 ENV MAVEN_HOME="/opt/maven/apache-maven-3.8.2"
-ENV JAVA_HOME="/opt/jdk/zulu17"
+ENV JAVA_HOME="/opt/jdk/zulu21"
 ENV PATH="$JAVA_HOME/bin:$PATH:$MAVEN_HOME/bin"


### PR DESCRIPTION
- Trocando os links de download para a versão 21.44.17 disponível 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded runtime from Java 17 to Java 21 for container builds (amd64 and arm64).
  * Improves performance, security, and long-term support without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->