### PR TITLE
fix: atualizar imagem do Node e versões do Maven e Zulu JDK no Docker…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,13 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-FROM node:20.17-bullseye-slim
+FROM node:20.18-bookworm-slim
 ARG TARGETPLATFORM
-ENV DOWNLOAD_URL=invalid
-ENV ZULU_TAR=invalid
 RUN case "${TARGETPLATFORM}" in \
-         "linux/amd64")     DOWNLOAD_URL=https://cdn.azul.com/zulu/bin/zulu21.44.17-ca-jdk21.0.8-linux_x64.tar.gz               \
-                            ZULU_TAR="zulu21.44.17-ca-jdk21.0.8-linux_x64"        ;; \
-         "linux/arm64")     DOWNLOAD_URL=https://cdn.azul.com/zulu/bin/zulu21.44.17-ca-jdk21.0.8-linux_aarch64.tar.gz           \
-                            ZULU_TAR="zulu21.44.17-ca-jdk21.0.8-linux_aarch64"    ;; \
+         "linux/amd64")     export DOWNLOAD_URL=https://cdn.azul.com/zulu/bin/zulu21.44.17-ca-jdk21.0.8-linux_x64.tar.gz && \
+                            export ZULU_TAR="zulu21.44.17-ca-jdk21.0.8-linux_x64"        ;; \
+         "linux/arm64")     export DOWNLOAD_URL=https://cdn.azul.com/zulu/bin/zulu21.44.17-ca-jdk21.0.8-linux_aarch64.tar.gz && \
+                            export ZULU_TAR="zulu21.44.17-ca-jdk21.0.8-linux_aarch64"    ;; \
     esac && \
     apt-get update -qq && apt-get upgrade -qq --autoremove --purge && \
     apt-get install -qq wget git java-common libasound2 libxi6 libxtst6 && \
@@ -35,10 +33,10 @@ RUN case "${TARGETPLATFORM}" in \
     tar -C /opt/jdk -xzf ./${ZULU_TAR}.tar.gz && \
     mv /opt/jdk/${ZULU_TAR} /opt/jdk/zulu21 && \
     rm ./${ZULU_TAR}.tar.gz && \
-    wget https://dlcdn.apache.org/maven/maven-3/3.8.2/binaries/apache-maven-3.8.2-bin.tar.gz && \
-    tar -C /opt/maven/ -xzf ./apache-maven-3.8.2-bin.tar.gz && \
-    rm ./apache-maven-3.8.2-bin.tar.gz
+    wget https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz && \
+    tar -C /opt/maven/ -xzf ./apache-maven-3.9.11-bin.tar.gz && \
+    rm ./apache-maven-3.9.11-bin.tar.gz
 
-ENV MAVEN_HOME="/opt/maven/apache-maven-3.8.2"
+ENV MAVEN_HOME="/opt/maven/apache-maven-3.9.11"
 ENV JAVA_HOME="/opt/jdk/zulu21"
 ENV PATH="$JAVA_HOME/bin:$PATH:$MAVEN_HOME/bin"


### PR DESCRIPTION
This pull request updates the `Dockerfile` to use newer base images and tools, and refactors how environment variables are set for platform-specific builds. The main changes center around upgrading dependencies and improving build script robustness.

**Dependency upgrades:**

* Updated the Node.js base image from `node:20.17-bullseye-slim` to `node:20.18-bookworm-slim` for improved security and compatibility.
* Upgraded Apache Maven from version 3.8.2 to 3.9.11, including updating the download URL and the `MAVEN_HOME` environment variable.

**Build script improvements:**

* Changed how platform-specific environment variables (`DOWNLOAD_URL`, `ZULU_TAR`) are set in the build script: now using `export` within the shell rather than setting them as Docker environment variables, which improves reliability during multi-platform builds.…file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Dockerfile to Node 20.18 bookworm, upgrades Maven to 3.9.11, and switches Zulu JDK URL vars to shell exports per platform.
> 
> - **Dockerfile**:
>   - **Base Image**: `node:20.17-bullseye-slim` -> `node:20.18-bookworm-slim`.
>   - **Maven**: Download and `MAVEN_HOME` updated from `3.8.2` -> `3.9.11`.
>   - **Platform vars**: Replace global `ENV DOWNLOAD_URL`/`ZULU_TAR` with per-platform `export` in `case` block.
>   - **Paths/Env**: Keep `JAVA_HOME` and `PATH` intact with new `MAVEN_HOME`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2141dee7da09dbce251215f4f3f9289b6b81f36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base to Node 20.18 (bookworm-slim).
  * Upgraded bundled Maven to 3.9.11 and updated MAVEN_HOME accordingly.
  * Streamlined JDK and Maven installation to avoid leftover artifacts.
  * Improved multi-architecture handling (amd64/arm64) during JDK setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->